### PR TITLE
Removed Spotify Service IP because it changed in the meantime

### DIFF
--- a/buildroot/package/spotifyd/spotify.service
+++ b/buildroot/package/spotifyd/spotify.service
@@ -12,7 +12,6 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
 Environment=SPOTIFYD_CLIENT_ID=9223bb6a6d924c8da9b02519d03c987a
 ExecStartPre=/opt/hifiberry/bin/bootmsg "Starting Spotify"
 ExecStartPre=/opt/hifiberry/bin/store-volume /tmp/spotifyvol
-ExecStartPre=/opt/hifiberry/bin/set-host-ip ap-gew4.spotify.com 104.199.65.124
 ExecStart=/opt/hifiberry/bin/spotify-start
 ExecStartPost=sleep 1
 ExecStartPost=/opt/hifiberry/bin/restore-volume /tmp/spotifyvol


### PR DESCRIPTION
I removed the command for the host entry because the IP changed and now the question is if it really makes sense to create a static entry in that case. 